### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/components/Achievements.jsx
+++ b/components/Achievements.jsx
@@ -23,6 +23,10 @@ const itemVariants = {
 };
 
 // Convert a variety of Google Drive share links to a preview-friendly URL
+const ALLOWED_DRIVE_HOSTNAMES = [
+  'drive.google.com',
+  'docs.google.com' // Add more if needed for preview support
+];
 function toDrivePreviewUrl(url) {
   if (!url) return '';
   try {
@@ -34,7 +38,7 @@ function toDrivePreviewUrl(url) {
     let id = '';
     const pathParts = u.pathname.split('/').filter(Boolean);
     const i = pathParts.indexOf('d');
-    if (u.hostname.includes('drive.google.com') && i !== -1 && pathParts[i + 1]) {
+    if (ALLOWED_DRIVE_HOSTNAMES.includes(u.hostname) && i !== -1 && pathParts[i + 1]) {
       id = pathParts[i + 1];
     }
     if (!id) {


### PR DESCRIPTION
Potential fix for [https://github.com/aryanzkys/my-profiles/security/code-scanning/2](https://github.com/aryanzkys/my-profiles/security/code-scanning/2)

To fix the problem, replace the substring hostname check with a **strict whitelist** of allowed hostnames for Google Drive. Specifically, compare `u.hostname` exactly (or, in the case of subdomains, use an explicit list, e.g. `drive.google.com`, `docs.google.com`). Replace code at line 37 with a more robust whitelisting check:  
- Build an array of allowed `hostname` values, such as `['drive.google.com', 'docs.google.com']`, and check for equality (`includes(u.hostname)`), not substring.  
- No changes to existing imports are required; standard JS/React functionality suffices.

You only need to make edits within the `toDrivePreviewUrl` function in `components/Achievements.jsx`:
- Define an array of allowed hostnames just above the function.
- Replace the substring `.includes('drive.google.com')` check in line 37 with `.includes(u.hostname)` using that array.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
